### PR TITLE
corrected the revision viewer on the wiki

### DIFF
--- a/app/views/wiki/revisions.html.erb
+++ b/app/views/wiki/revisions.html.erb
@@ -61,7 +61,7 @@
       older = old
       $('#newer').html(newer)
       $('#older').html(older)
-      $('#diff').html(diffString($('#body_'+newer).html(),$('#body_'+older).html()))
+      $('#diff').html(diffString($('#body_'+older).html(),$('#body_'+newer).html()))
       $('tr').removeClass('warning')
       $('#row'+older).addClass('warning')
       $('#row'+newer).addClass('warning')


### PR DESCRIPTION
The diffString() within the goto() had incorrectly ordered the newer/older HTML string parameters, so wiki additions appeared as subtractions.
