### PR TITLE
Remove excess users table alterations

### DIFF
--- a/db/migrate/20130114213934_add_profile_tags.rb
+++ b/db/migrate/20130114213934_add_profile_tags.rb
@@ -8,8 +8,8 @@ class AddProfileTags < ActiveRecord::Migration
       t.text :body
       t.timestamps
     end
-    add_column :users, :lat, :decimal, :precision => 20, :scale => 10, :default => 0.0
-    add_column :users, :lon, :decimal, :precision => 20, :scale => 10, :default => 0.0
+    #add_column :users, :lat, :decimal, :precision => 20, :scale => 10, :default => 0.0
+    #add_column :users, :lon, :decimal, :precision => 20, :scale => 10, :default => 0.0
   end
 
   def down


### PR DESCRIPTION
Tried db:migrate and got stuck on this stuff: lat and lon already declared in Drupal migrations (20120101000000_drupal_schema.rb).
