### PR TITLE
Add HTML entity newline to RSS feed between header image and markdown content.

### DIFF
--- a/app/views/users/rss.rss.builder
+++ b/app/views/users/rss.rss.builder
@@ -7,8 +7,10 @@ xml.rss :version => "2.0" do
 
    @notes.each do |node|
 
+    newline = '&#13;&#10;'
+
      body = node.body
-     body = "<img src='"+node.main_image.path(:default)+"'/><br /> "+node.body if node.main_image
+     body = "<img src='"+node.main_image.path(:default)+"'/><br />"+newline+node.body if node.main_image
 
      xml.item do
        xml.title       node.title


### PR DESCRIPTION
This solves a problem where the introductory header of the research note is ignored by the markdown parser because it is not preceded by a newline.

When research notes are rendered into an RSS feed, the header image is appended to the beginning of the markdown body using simple string concatenation.  This means that there is no longer a newline before the markdown content, and so the header, indicated by `###`, is not recognized.

For example, from my own feed: 

```
<img src='http://i.publiclab.org/system/images/photos/000/006/340/medium/IMAG0382.jpg'/><br /> ### What I want to do I want to have a discussion about how we might embed Riffle data in MapKnitter as map annotations.
```

A `<br />` tag has been inserted after the image - but because there is no newline between the `<img>` tag and the `###` meant to indicate a header, the `###` will not be parsed into an `<h3>` tag.

This PR addresses that issue by inserting a newline (`&#13;&#10;`) between the image tag and the markdown content.
