### PR TITLE
Adjustment to routes.rb for Issues #856 #854

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,8 +134,6 @@ Plots2::Application.routes.draw do
   match 'questions_search/typeahead/:id' => 'questions_search#typeahead'
 
   #Search Pages
-  # match 'search' => 'searches#new'
-  # match 'search/advanced' => 'searches#new'
   match 'search/advanced/:id' => 'searches#new'
   match 'search/dynamic' => 'searches#dynamic'
   match 'search/dynamic/:id' => 'searches#dynamic'
@@ -143,7 +141,9 @@ Plots2::Application.routes.draw do
   match 'search/questions/:id' => 'searches#questions'
   match 'search/questions_typeahead/:id' => 'searches#questions_typeahead'
   match 'search/:id' => 'searches#normal_search'
-
+  match 'search/advanced' => 'searches#new'
+  match 'search' => 'searches#new'
+  
   # Question Search capability--temporary until combined with full Search Capabilities
   match 'questions_search/:id' => 'questions_search#index'
   match 'questions_search/typeahead/:id' => 'questions_search#typeahead'

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -3,7 +3,7 @@ production:
     hostname: localhost
     port: 8983
     log_level: WARNING
-    path: /solr/default
+    path: /solr/production
     # read_timeout: 2
     # open_timeout: 0.5
 

--- a/test/integration/search_flow_test.rb
+++ b/test/integration/search_flow_test.rb
@@ -1,22 +1,28 @@
 require 'test_helper'
 
+# Test the get/post actions for the search forms
 class SearchFlowTest < ActionDispatch::IntegrationTest
 
   test "advanced search basic test" do
     # "key_words"=>"post", "main_type"=>"Notes or Wiki updates", "language"=>"", "min_date"=>"", "max_date"=>""
-
-    get '/searches/new'
-
+    
+    # Perform a URL GET search with a search term
+    get '/search/map'
     assert_response :success
 
-    post '/searches', 
+    # Perform a URL GET search without a term
+    get '/search'
+    assert_response :success
+
+    # Perform a POST search submission without a term
+    post '/search', 
          key_words: "blog",
          main_type: "Notes or Wiki updates"
 
     assert_response :success
-
-    get '/searches/new'
-
+ 
+    #  Perform a GET search call to advanced without a search term
+    get '/search/advanced'
     assert_response :success
 
   end


### PR DESCRIPTION
Change to routes.rb to have search catch-all rule.  Adjusted URLs in search_flow_test.rb to match normal usage.

* [x] All tests pass -- `rake test:all`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [x] pull request are descriptively named
* [x] if possible, multiple commits squashed if they're smaller changes
* [x] reviewed/confirmed/tested by another contributor or maintainer
* [x] `schema.rb.example` has been updated if any database migrations were added

